### PR TITLE
[FEATURE][Noshow]회원가입 노쇼로직 추가

### DIFF
--- a/src/main/java/com/ohgiraffers/ukki/user/controller/EmailController.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/controller/EmailController.java
@@ -41,13 +41,11 @@ public class EmailController {
 
         // 이메일
         if (isDuplicate) {
-            response.put("message", "이 이메일은 이미 사용 중입니다."); // 중복
             return ResponseEntity.status(HttpStatus.CONFLICT).body(response); // 409 Conflict
         }
 
         // 노쇼
         if (isNoshowLimitExceeded) {
-            response.put("message", "이 이메일의 노쇼 횟수가 3회 이상입니다. 가입이 불가합니다."); // 노쇼
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response); // 403 Forbidden
         }
 

--- a/src/main/java/com/ohgiraffers/ukki/user/controller/EmailController.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/controller/EmailController.java
@@ -32,16 +32,27 @@ public class EmailController {
     public ResponseEntity<Map<String, Object>> checkEmail(@RequestBody Map<String, String> request) {
         String email = request.get("email");
 
-        boolean isDuplicate = emailService.isEmailDuplicate(email);
+        boolean isDuplicate = emailService.isEmailDuplicate(email); // 중복
+        boolean isNoshowLimitExceeded = emailService.isNoshowLimitExceeded(email); // 노쇼
 
         Map<String, Object> response = new HashMap<>();
         response.put("isDuplicate", isDuplicate);
+        response.put("isNoshowLimitExceeded", isNoshowLimitExceeded);
 
+        // 이메일
         if (isDuplicate) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(response);  // 이메일이 중복된 경우
-        } else {
-            return ResponseEntity.ok(response);
+            response.put("message", "이 이메일은 이미 사용 중입니다."); // 중복
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(response); // 409 Conflict
         }
+
+        // 노쇼
+        if (isNoshowLimitExceeded) {
+            response.put("message", "이 이메일의 노쇼 횟수가 3회 이상입니다. 가입이 불가합니다."); // 노쇼
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response); // 403 Forbidden
+        }
+
+        // 정상
+        return ResponseEntity.ok(response); // 200 OK
     }
 
     @PostMapping("/sendemail")

--- a/src/main/java/com/ohgiraffers/ukki/user/model/dao/EmailMapper.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/dao/EmailMapper.java
@@ -4,5 +4,7 @@ import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface EmailMapper {
-    int countByEmail(String email);
+    Integer countByEmail(String email);
+
+    Integer getNoshowCountByEmail(String email);
 }

--- a/src/main/java/com/ohgiraffers/ukki/user/model/dao/SignupMapper.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/dao/SignupMapper.java
@@ -11,4 +11,10 @@ public interface SignupMapper {
     int signupNickname(String userName);
 
     void signup(SignupUserDTO signupUserDTO);
+
+    // 노쇼에 대한 로직
+
+    int getNoshowCountByEmail(String email);
+
+    void removeEmailFromNoshow(String email);
 }

--- a/src/main/java/com/ohgiraffers/ukki/user/model/dto/SignupUserDTO.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/dto/SignupUserDTO.java
@@ -6,14 +6,16 @@ public class SignupUserDTO {
     private String userPass;
     private String email;
     private String userName;
+    private int noshow;
 
     public SignupUserDTO() {}
 
-    public SignupUserDTO(String userId, String userPass, String email, String userName) {
+    public SignupUserDTO(String userId, String userPass, String email, String userName, int noshow) {
         this.userId = userId;
         this.userPass = userPass;
         this.email = email;
         this.userName = userName;
+        this.noshow = noshow;
     }
 
     public String getUserId() {
@@ -48,6 +50,14 @@ public class SignupUserDTO {
         this.userName = userName;
     }
 
+    public int getNoshow() {
+        return noshow;
+    }
+
+    public void setNoshow(int noshow) {
+        this.noshow = noshow;
+    }
+
     @Override
     public String toString() {
         return "SignupUserDTO{" +
@@ -55,6 +65,7 @@ public class SignupUserDTO {
                 ", userPass='" + userPass + '\'' +
                 ", email='" + email + '\'' +
                 ", userName='" + userName + '\'' +
+                ", noshow=" + noshow +
                 '}';
     }
 }

--- a/src/main/java/com/ohgiraffers/ukki/user/model/service/EmailService.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/service/EmailService.java
@@ -71,4 +71,9 @@ public class EmailService {
 
         return storedCode != null && storedCode.equals(authCode);
     }
+
+    public boolean isNoshowLimitExceeded(String email) {
+        int noshowCount = emailMapper.getNoshowCountByEmail(email);
+        return noshowCount >= 3;
+    }
 }

--- a/src/main/java/com/ohgiraffers/ukki/user/model/service/SignupService.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/service/SignupService.java
@@ -55,7 +55,7 @@ public class SignupService {
             signupUserDTO.setUserPass(hashedPassword);
 
             int noshowCount = signupMapper.getNoshowCountByEmail(signupUserDTO.getEmail()); // DTO에서 이메일 가져와서 그 이메일의 NOSHOW 횟수를 가져오라
-            System.out.println(noshowCount); // 여기까지 반환 잘됨
+//            System.out.println(noshowCount); // 여기까지 반환 잘됨
             if (noshowCount > 0) {
                 signupUserDTO.setNoshow(noshowCount); // 만약 반환된 값이 0보다 크면 값을 DTO의 noshow 횟수로 설정혀라
                 signupMapper.signup(signupUserDTO); // 회원가입 시키기

--- a/src/main/java/com/ohgiraffers/ukki/user/model/service/SignupService.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/service/SignupService.java
@@ -55,7 +55,7 @@ public class SignupService {
             signupUserDTO.setUserPass(hashedPassword);
 
             int noshowCount = signupMapper.getNoshowCountByEmail(signupUserDTO.getEmail()); // DTO에서 이메일 가져와서 그 이메일의 NOSHOW 횟수를 가져오라
-//            System.out.println(noshowCount); // 여기까지 반환 잘됨
+//            System.out.println(noshowCount); 여기까지 반환 잘됨
             if (noshowCount > 0) {
                 signupUserDTO.setNoshow(noshowCount); // 만약 반환된 값이 0보다 크면 값을 DTO의 noshow 횟수로 설정혀라
                 signupMapper.signup(signupUserDTO); // 회원가입 시키기

--- a/src/main/java/com/ohgiraffers/ukki/user/model/service/SignupService.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/service/SignupService.java
@@ -54,7 +54,19 @@ public class SignupService {
             String hashedPassword = passwordEncoder.encode(signupUserDTO.getUserPass());
             signupUserDTO.setUserPass(hashedPassword);
 
-            signupMapper.signup(signupUserDTO);
+            int noshowCount = signupMapper.getNoshowCountByEmail(signupUserDTO.getEmail()); // DTO에서 이메일 가져와서 그 이메일의 NOSHOW 횟수를 가져오라
+            System.out.println(noshowCount); // 여기까지 반환 잘됨
+            if (noshowCount > 0) {
+                signupUserDTO.setNoshow(noshowCount); // 만약 반환된 값이 0보다 크면 값을 DTO의 noshow 횟수로 설정혀라
+                signupMapper.signup(signupUserDTO); // 회원가입 시키기
+                // 이제 업데이트는 쿼리문이 아닌 여기서 해준 상태라고 볼 수 있고
+                // 값을 가져왔으니 기존 노쇼에선 제거해줄것
+                signupMapper.removeEmailFromNoshow(signupUserDTO.getEmail()); // DTO에서 이메일 가져와서 그 이메일 삭제혀라
+
+            } else {
+                signupUserDTO.setNoshow(0);
+                signupMapper.signup(signupUserDTO);
+            }
             return true;
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/resources/mappers/EmailMapper.xml
+++ b/src/main/resources/mappers/EmailMapper.xml
@@ -5,8 +5,14 @@
 
 <mapper namespace="com.ohgiraffers.ukki.user.model.dao.EmailMapper">
     <select id="countByEmail" parameterType="String" resultType="int">
-    SELECT COUNT(*)
-    FROM TBL_USER
-    WHERE Email = #{ email }
+        SELECT IFNULL(COUNT(*), 0)
+        FROM TBL_USER
+        WHERE EMAIL = #{ email }
+    </select>
+
+    <select id="getNoshowCountByEmail" parameterType="String" resultType="int">
+        SELECT IFNULL(SUM(NOSHOW), 0)
+        FROM TBL_NOSHOW
+        WHERE EMAIL = #{ email }
     </select>
 </mapper>

--- a/src/main/resources/mappers/SignupMapper.xml
+++ b/src/main/resources/mappers/SignupMapper.xml
@@ -22,14 +22,16 @@
         USER_ID,
         USER_PWD,
         EMAIL,
-        USER_NAME
+        USER_NAME,
+        NOSHOW
         )
         VALUES
         (
         #{userId},
         #{userPass},
         #{email},
-        #{userName}
+        #{userName},
+        #{noshow}
         )
     </insert>
 </mapper>

--- a/src/main/resources/mappers/SignupMapper.xml
+++ b/src/main/resources/mappers/SignupMapper.xml
@@ -34,4 +34,17 @@
         #{noshow}
         )
     </insert>
+
+    <select id="getNoshowCountByEmail" resultType="int" parameterType="String">
+        SELECT
+        IFNULL(SUM(NOSHOW), 0)
+        FROM TBL_NOSHOW
+        WHERE EMAIL = #{ email }
+    </select>
+
+    <delete id="removeEmailFromNoshow" parameterType="String">
+        DELETE
+        FROM TBL_NOSHOW
+        WHERE EMAIL = #{ email }
+    </delete>
 </mapper>


### PR DESCRIPTION
## 기능 설명 (필수) 😊
> 탈퇴로직은 추가되지 않았으나 탈퇴 시에 noshow 횟수가 있다면 noshow 테이블에 추가될 예정입니다.
> 그에 따라 다시 가입하게 되면 노쇼 테이블에 있는 이메일과 값을 비교해서 3이상이면 가입이 불가할 예정이고 그 미만인 1과 >2의 경우에는 가입 시에 노쇼 횟수가 회원가입 시에 업데이트 되게 하였습니다.
<br/>

## 관련 이슈번호 (필수) ✅
#48 
<br/>

## 다른 리뷰어들이 참고해야할 사항을 적어주세요. (선택) 💬
> 업데이트 쿼리문을 통해 하려고 생각했을 때 복잡하단 생각이 들었는데 가입 단계에서 DTO에 담아주는걸 해주는 과정으로 간단하게 처리할 수 있었네요.
<br/>

## 기능 관련한 이미지 작성바랍니다. (선택) 🖼
가입 불가 (탈퇴 시 노쇼가 3회)
![image](https://github.com/user-attachments/assets/7d1163d1-3cc1-4aa4-b83d-310581b78365)
<hr/>

가입 전 TBL_NOSHOW
![image](https://github.com/user-attachments/assets/d8ac94ca-0771-47c0-908d-e3dc76331619)
<hr/>

TBL_USER
![image](https://github.com/user-attachments/assets/822c1002-5302-4b3b-922f-94ec10fe4421)
<hr/>

TBL_NOSHOW
![image](https://github.com/user-attachments/assets/22c4f46a-da12-4682-916f-efc49e63d07d)
