### PR TITLE
[FEATURE][UpdateInquiryStatus]사용자가 답변이 달린 글을 읽었을 때 확인 완료로 변경하는 로직

### DIFF
--- a/src/main/java/com/ohgiraffers/ukki/user/controller/MypageController.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/controller/MypageController.java
@@ -1,6 +1,7 @@
 package com.ohgiraffers.ukki.user.controller;
 
 import com.ohgiraffers.ukki.auth.model.service.JwtService;
+import com.ohgiraffers.ukki.common.InquiryState;
 import com.ohgiraffers.ukki.user.model.dto.MypageDTO;
 import com.ohgiraffers.ukki.user.model.dto.MypageInquiryDTO;
 import com.ohgiraffers.ukki.user.model.dto.MypageReservationDTO;
@@ -18,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/user")
+@RequestMapping("/user/mypage")
 public class MypageController {
 
     private final JwtService jwtService;
@@ -151,6 +152,44 @@ public class MypageController {
 
         return ResponseEntity.ok(inquiry);
     }
+
+    @PutMapping("/inquiry/{inquiryNo}/status")
+    public ResponseEntity<String> updateInquiryStatusToRead(@PathVariable int inquiryNo, HttpServletRequest request) {
+        String jwtToken = cookieService.getJWTCookie(request);
+        if (jwtToken == null) {
+            throw new IllegalArgumentException("토큰이 일치하지 않음");
+        }
+
+        String userId = jwtService.getUserInfoFromTokenId(jwtToken);
+        if (userId == null) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
+        List<MypageInquiryDTO> inquiries = mypageService.getUserInquiryFromToken(jwtToken, userId);
+
+        MypageInquiryDTO inquiry = inquiries.stream()
+                .filter(i -> i.getInquiryNo() == inquiryNo)
+                .findFirst()
+                .orElse(null);
+
+
+        if (inquiry == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("해당 문의를 찾을 수 없습니다.");
+        }
+
+        if (inquiry.getAnswerDate() != null && inquiry.getInquiryState() != InquiryState.CHECK) {
+            boolean updated = mypageService.updateInquiryStatus(inquiryNo, InquiryState.CHECK);
+            if (updated) {
+                return ResponseEntity.ok("문의 상태가 '읽음'으로 업데이트되었습니다.");
+            } else {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("상태 업데이트에 실패했습니다.");
+            }
+        } else {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("답변이 없습니다.");
+        }
+    }
+
+
 
 
 }

--- a/src/main/java/com/ohgiraffers/ukki/user/controller/MypageController.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/controller/MypageController.java
@@ -53,23 +53,6 @@ public class MypageController {
         return mypageService.getUserInfoFromToken(jwtToken, userId);
     }*/
 
-//    httpOnly를 사용하면서 이 방식으로 전부 백엔드에서 사용합니다.
-    @GetMapping("/info")
-    public MypageDTO getUserInfo(HttpServletRequest request) {
-        String jwtToken = cookieService.getJWTCookie(request);
-
-        if (jwtToken == null) {
-            throw new IllegalArgumentException("토큰이 일치하지 않음");
-        }
-
-        String userId = jwtService.getUserInfoFromTokenId(jwtToken);
-
-        if (userId == null) {
-            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
-        }
-
-        return mypageService.getUserInfoFromToken(jwtToken, userId);
-    }
 
     @GetMapping("/reservation")
     public ResponseEntity<List<MypageReservationDTO>> getUserReservation(HttpServletRequest request) {

--- a/src/main/java/com/ohgiraffers/ukki/user/controller/UserController.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/controller/UserController.java
@@ -1,4 +1,45 @@
 package com.ohgiraffers.ukki.user.controller;
 
+import com.ohgiraffers.ukki.auth.model.service.JwtService;
+import com.ohgiraffers.ukki.user.model.dto.MypageDTO;
+import com.ohgiraffers.ukki.user.model.service.CookieService;
+import com.ohgiraffers.ukki.user.model.service.MypageService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/user")
 public class UserController {
+
+    private JwtService jwtService;
+    private MypageService mypageService;
+    private CookieService cookieService;
+
+    @Autowired
+    public UserController (MypageService mypageService, CookieService cookieService, JwtService jwtService) {
+        this.mypageService = mypageService;
+        this.cookieService = cookieService;
+        this.jwtService = jwtService;
+    }
+
+    //    httpOnly를 사용하면서 이 방식으로 전부 백엔드에서 사용합니다.
+    @GetMapping("/info")
+    public MypageDTO getUserInfo(HttpServletRequest request) {
+        String jwtToken = cookieService.getJWTCookie(request);
+
+        if (jwtToken == null) {
+            throw new IllegalArgumentException("토큰이 일치하지 않음");
+        }
+
+        String userId = jwtService.getUserInfoFromTokenId(jwtToken);
+
+        if (userId == null) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
+        return mypageService.getUserInfoFromToken(jwtToken, userId);
+    }
 }

--- a/src/main/java/com/ohgiraffers/ukki/user/model/dao/MypageMapper.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/dao/MypageMapper.java
@@ -1,5 +1,6 @@
 package com.ohgiraffers.ukki.user.model.dao;
 
+import com.ohgiraffers.ukki.common.InquiryState;
 import com.ohgiraffers.ukki.user.model.dto.MypageDTO;
 import com.ohgiraffers.ukki.user.model.dto.MypageInquiryDTO;
 import com.ohgiraffers.ukki.user.model.dto.MypageReservationDTO;
@@ -19,4 +20,6 @@ public interface MypageMapper {
     int deleteReviewById(int reviewNo);
 
     List<MypageInquiryDTO> findUserInquiryByUserId(String userId);
+
+    int updateInquiryStatus(int inquiryNo, InquiryState inquiryState);
 }

--- a/src/main/java/com/ohgiraffers/ukki/user/model/dao/MypageMapper.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/dao/MypageMapper.java
@@ -22,4 +22,6 @@ public interface MypageMapper {
     List<MypageInquiryDTO> findUserInquiryByUserId(String userId);
 
     int updateInquiryStatus(int inquiryNo, InquiryState inquiryState);
+
+    int updateInquiry(MypageInquiryDTO inquiryToUpdate);
 }

--- a/src/main/java/com/ohgiraffers/ukki/user/model/service/MypageService.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/service/MypageService.java
@@ -123,4 +123,15 @@ public class MypageService {
         return result > 0;
     }
 
+    public boolean updateInquiry(MypageInquiryDTO inquiryToUpdate) {
+        try {
+            int updatedRows = mypageMapper.updateInquiry(inquiryToUpdate);
+
+            // 업데이트된 행이 있으면 true 반환
+            return updatedRows > 0;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
 }

--- a/src/main/java/com/ohgiraffers/ukki/user/model/service/MypageService.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/service/MypageService.java
@@ -1,6 +1,7 @@
 package com.ohgiraffers.ukki.user.model.service;
 
 import com.ohgiraffers.ukki.auth.model.service.JwtService;
+import com.ohgiraffers.ukki.common.InquiryState;
 import com.ohgiraffers.ukki.user.model.dao.MypageMapper;
 import com.ohgiraffers.ukki.user.model.dto.MypageDTO;
 import com.ohgiraffers.ukki.user.model.dto.MypageInquiryDTO;
@@ -115,4 +116,11 @@ public class MypageService {
 
         return inquiry;
     }
+
+    public boolean updateInquiryStatus(int inquiryNo, InquiryState inquiryState) {
+        int result = mypageMapper.updateInquiryStatus(inquiryNo, inquiryState);
+
+        return result > 0;
+    }
+
 }

--- a/src/main/resources/mappers/mypage/MypageMapper.xml
+++ b/src/main/resources/mappers/mypage/MypageMapper.xml
@@ -107,4 +107,10 @@
         i.INQ_NO DESC;
     </select>
 
+    <update id="updateInquiryStatus" parameterType="map">
+        UPDATE TBL_INQUIRY
+        SET STATE = #{inquiryState}
+        WHERE INQ_NO = #{inquiryNo}
+    </update>
+
 </mapper>

--- a/src/main/resources/mappers/mypage/MypageMapper.xml
+++ b/src/main/resources/mappers/mypage/MypageMapper.xml
@@ -113,4 +113,11 @@
         WHERE INQ_NO = #{inquiryNo}
     </update>
 
+    <update id="updateInquiry" parameterType="com.ohgiraffers.ukki.user.model.dto.MypageInquiryDTO">
+        UPDATE TBL_INQUIRY
+        SET INQ_TITLE = #{title},
+        INQ_CONTENT = #{text}
+        WHERE INQ_NO = #{inquiryNo}
+    </update>
+
 </mapper>


### PR DESCRIPTION
## 기능 설명 (필수) 😊
> 사용자가 답변이 달린 문의 글을 읽으면 읽음(확인완료) 표시되게 변경했습니다.
<br/>

## 관련 이슈번호 (필수) ✅
#135 
<br/>

## 다른 리뷰어들이 참고해야할 사항을 적어주세요. (선택) 💬
> 추가로 user/info 사용하시는 분들이 있을 것 같은데 제가 mypage에 쓰는 모든 api에 R.M에 mypage까지 추가해서 /user/mypage가 다 붙었는데 MypageController에 info까지 mypage가 붙으면서 사용하신 모든 로직에서 오류가 남을 확인했습니다.
>
> 따라서 기존에 있던 info api는 userController에 기존 /user/info로 뺐으니 참고만 하시고 그대로 사용하시면 됩니다.
>
> 감사합니다.
<br/>

## 기능 관련한 이미지 작성바랍니다. (선택) 🖼
처리 완료(유저가 문의한 문의내역에 대한 관리자의 답변이 달린 상태)
![image](https://github.com/user-attachments/assets/13d0ec59-32fc-4ae5-a587-25b54caec0a6)

확인 완료(유저가 문의답변이 달린 글을 들어갔을 때)
![image](https://github.com/user-attachments/assets/6193ff4a-dbc2-4c0a-9cab-de59db0c3fd1)

처리중 (유저가 문의했으나 답변이 달리지 않은 상태) - 변화 없음
![image](https://github.com/user-attachments/assets/23d2eb76-9f74-4b1c-8829-1b405efaa741)
![image](https://github.com/user-attachments/assets/2c1bc54f-dc17-402f-be5f-c3b1e03892eb)
![image](https://github.com/user-attachments/assets/81dcf6f2-5943-4ab7-9d56-d6249de68b68)
