### PR TITLE
[FEATURE][MypagePDeleteAccount]마이페이지 계정 탈퇴 로직

### DIFF
--- a/src/main/java/com/ohgiraffers/ukki/auth/controller/AuthController.java
+++ b/src/main/java/com/ohgiraffers/ukki/auth/controller/AuthController.java
@@ -8,7 +8,9 @@ import com.ohgiraffers.ukki.common.UserRole;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -138,15 +140,30 @@ public class AuthController {
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
         try {
+            // 세션 무효화
+            HttpSession session = request.getSession(false);
+            if (session != null) {
+                session.invalidate();  // 세션 종료
+            }
+
+            // 쿠키 삭제
             deleteCookie(request, response, "authToken");
             deleteCookie(request, response, "refreshToken");
 
-            return ResponseEntity.ok(Map.of("success", true, "message", "ⓘ 로그아웃 성공"));
+            // JSON 응답을 명시적으로 반환
+            return ResponseEntity.ok()
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Map.of("success", true, "message", "ⓘ 로그아웃 성공"));
         } catch (Exception e) {
+            // 서버 오류 발생 시, JSON 형식으로 반환
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .contentType(MediaType.APPLICATION_JSON)
                     .body(Map.of("success", false, "message", "ⓘ 서버 오류가 발생했습니다."));
         }
     }
+
+
+
 
     private void deleteCookie(HttpServletRequest request, HttpServletResponse response, String cookieName) {
         Cookie[] cookies = request.getCookies();

--- a/src/main/java/com/ohgiraffers/ukki/config/SecurityConfig.java
+++ b/src/main/java/com/ohgiraffers/ukki/config/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
                 .addFilterBefore(logoutFilter, JwtFilter.class) // 로그아웃 필터 추가 (JwtFilter 전)
                 .logout(logout -> logout
                         .logoutUrl("/auth/logout")
+                        .logoutSuccessUrl("http://localhost:3000/")
                         .invalidateHttpSession(true)
                         .clearAuthentication(true)
                         .deleteCookies("authToken", "refreshToken")

--- a/src/main/java/com/ohgiraffers/ukki/user/controller/MypageController.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/controller/MypageController.java
@@ -250,7 +250,6 @@ public class MypageController {
 
         System.out.println(file);
 
-        // JWT 토큰 검사
         String jwtToken = cookieService.getJWTCookie(request);
         if (jwtToken == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
@@ -263,12 +262,10 @@ public class MypageController {
                     .body(Collections.singletonMap("message", "유효하지 않은 토큰입니다."));
         }
 
-        // 사용자 문의 정보 가져오기
         List<MypageInquiryDTO> inquiries = mypageService.getUserInquiryFromToken(jwtToken, userId);
 
         System.out.println("zz");
 
-        // 수정할 문의 찾기
         MypageInquiryDTO inquiryToUpdate = inquiries.stream()
                 .filter(i -> i.getInquiryNo() == inquiryNo)
                 .findFirst()
@@ -279,11 +276,9 @@ public class MypageController {
                     .body(Collections.singletonMap("message", "해당 문의를 찾을 수 없습니다."));
         }
 
-        // 제목과 내용 수정
         inquiryToUpdate.setTitle(title);
         inquiryToUpdate.setText(text);
 
-        // 파일 업로드 처리 (파일이 있을 때만)
         if (file != null && !file.isEmpty()) {
             try {
                 boolean updated = mypageService.updateInquiry(inquiryToUpdate, file, userId);

--- a/src/main/java/com/ohgiraffers/ukki/user/controller/MypageController.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/controller/MypageController.java
@@ -458,7 +458,7 @@ public class MypageController {
 
     @DeleteMapping("/delete")
     public ResponseEntity<String> deleteUser(HttpServletRequest request) {
-        String jwtToken = cookieService.getJWTCookie(request); // 쿠키에서 JWT 토큰을 가져옵니다.
+        String jwtToken = cookieService.getJWTCookie(request);
 
         if (jwtToken == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("토큰이 유효하지 않습니다.");

--- a/src/main/java/com/ohgiraffers/ukki/user/model/dao/MypageMapper.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/dao/MypageMapper.java
@@ -41,4 +41,10 @@ public interface MypageMapper {
     int deleteUserById(String userId);
 
     MypageReservationDetailDTO findReservationDetailByResNo(int resNo);
+
+    Long getUserNoById(String userId);
+
+    List<String> getReviewImagesByUserId(Long userNo);
+
+    int deleteReviewsByUserId(Long userNo);
 }

--- a/src/main/java/com/ohgiraffers/ukki/user/model/dao/MypageMapper.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/dao/MypageMapper.java
@@ -52,7 +52,7 @@ public interface MypageMapper {
 
     String getEmailByUserNo(Long userNo);
 
-    int insertEmailIntoNoshow(String email);
-
     MypageDeleteAccount getUserNoByIdForNoshow(String userId);
+
+    int insertEmailIntoNoshow(String email, int noshow);
 }

--- a/src/main/java/com/ohgiraffers/ukki/user/model/dao/MypageMapper.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/dao/MypageMapper.java
@@ -47,4 +47,12 @@ public interface MypageMapper {
     List<String> getReviewImagesByUserId(Long userNo);
 
     int deleteReviewsByUserId(Long userNo);
+
+    int getNoshowCountByUserNo(Long userNo);
+
+    String getEmailByUserNo(Long userNo);
+
+    int insertEmailIntoNoshow(String email);
+
+    MypageDeleteAccount getUserNoByIdForNoshow(String userId);
 }

--- a/src/main/java/com/ohgiraffers/ukki/user/model/dto/MypageDeleteAccount.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/dto/MypageDeleteAccount.java
@@ -1,0 +1,48 @@
+package com.ohgiraffers.ukki.user.model.dto;
+
+public class MypageDeleteAccount {
+    private Long userNo;
+    private String email;
+    private int noshowCount;
+
+    public MypageDeleteAccount() {}
+
+    public MypageDeleteAccount(Long userNo, String email, int noshowCount) {
+        this.userNo = userNo;
+        this.email = email;
+        this.noshowCount = noshowCount;
+    }
+
+    public Long getUserNo() {
+        return userNo;
+    }
+
+    public void setUserNo(Long userNo) {
+        this.userNo = userNo;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public int getNoshowCount() {
+        return noshowCount;
+    }
+
+    public void setNoshowCount(int noshowCount) {
+        this.noshowCount = noshowCount;
+    }
+
+    @Override
+    public String toString() {
+        return "MypageDeleteAccount{" +
+                "userNo=" + userNo +
+                ", email='" + email + '\'' +
+                ", noshowCount=" + noshowCount +
+                '}';
+    }
+}

--- a/src/main/java/com/ohgiraffers/ukki/user/model/service/MypageService.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/service/MypageService.java
@@ -415,8 +415,9 @@ public boolean updateProfileImage(String userId, MultipartFile profileImage) {
 
             if (mypageDeleteAccount.getNoshowCount() >= 1) {
                 String email = mypageDeleteAccount.getEmail();
+                int noshow = mypageDeleteAccount.getNoshowCount();
                 if (email != null) {
-                    int result = mypageMapper.insertEmailIntoNoshow(email);
+                    int result = mypageMapper.insertEmailIntoNoshow(email, noshow);
                     if (result == 0) {
                         throw new RuntimeException("Failed to insert email into TBL_NOSHOW");
                     }
@@ -430,7 +431,9 @@ public boolean updateProfileImage(String userId, MultipartFile profileImage) {
             if (profileImagePath != null) {
                 boolean isFileDeleted = deleteFile(profileImagePath);
                 if (!isFileDeleted) {
-                    throw new RuntimeException("Failed to delete profile image");
+                    throw new RuntimeException("프로필 이미지 제거 실패");
+                } else {
+                    System.out.println("프로필 사진 없음");
                 }
             }
 
@@ -462,9 +465,6 @@ public boolean updateProfileImage(String userId, MultipartFile profileImage) {
             throw new RuntimeException("Error deleting user: " + e.getMessage()); // 클라이언트로 에러 메시지 전달
         }
     }
-
-
-
 
     public boolean deleteFile(String filePath) {
         try {

--- a/src/main/java/com/ohgiraffers/ukki/user/model/service/MypageService.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/service/MypageService.java
@@ -408,6 +408,23 @@ public boolean updateProfileImage(String userId, MultipartFile profileImage) {
                 throw new RuntimeException("User not found for userId: " + userId);
             }
 
+            MypageDeleteAccount mypageDeleteAccount = mypageMapper.getUserNoByIdForNoshow(userId);
+            if (mypageDeleteAccount == null) {
+                throw new RuntimeException("User not found for userId: " + userId);
+            }
+
+            if (mypageDeleteAccount.getNoshowCount() >= 1) {
+                String email = mypageDeleteAccount.getEmail();
+                if (email != null) {
+                    int result = mypageMapper.insertEmailIntoNoshow(email);
+                    if (result == 0) {
+                        throw new RuntimeException("Failed to insert email into TBL_NOSHOW");
+                    }
+                } else {
+                    throw new RuntimeException("Email not found for userId: " + userId);
+                }
+            }
+
             // 프로필 이미지 삭제
             String profileImagePath = getExistingFilePath(userId);
             if (profileImagePath != null) {

--- a/src/main/java/com/ohgiraffers/ukki/user/model/service/MypageService.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/service/MypageService.java
@@ -376,34 +376,78 @@ public boolean updateProfileImage(String userId, MultipartFile profileImage) {
         }
     }
 
-    @Transactional // 여러 데이터베이스 연산을 하나의 트랜잭션으로 처리
+/*    @Transactional // 여러 데이터베이스 연산을 하나의 트랜잭션으로 처리
     public boolean deleteUser(String userId) {
         try {
-            // 1. 프로필 이미지 삭제
             String profileImagePath = getExistingFilePath(userId);
             if (profileImagePath != null) {
                 boolean isFileDeleted = deleteFile(profileImagePath);
                 if (!isFileDeleted) {
-                    // 파일 삭제 실패시 처리
                     return false;
                 }
             }
 
-            // 2. 사용자 정보 삭제 (Mapper 호출)
             int result = mypageMapper.deleteUserById(userId);
             if (result == 0) {
-                // 사용자 삭제 실패
                 return false;
             }
 
-            // 3. 성공적으로 처리된 경우
             return true;
         } catch (Exception e) {
             // 예외 처리
             e.printStackTrace();
             return false;
         }
+    }*/
+
+    @Transactional
+    public boolean deleteUser(String userId) {
+        try {
+            Long userNo = mypageMapper.getUserNoById(userId);
+            if (userNo == null) {
+                throw new RuntimeException("User not found for userId: " + userId);
+            }
+
+            // 프로필 이미지 삭제
+            String profileImagePath = getExistingFilePath(userId);
+            if (profileImagePath != null) {
+                boolean isFileDeleted = deleteFile(profileImagePath);
+                if (!isFileDeleted) {
+                    throw new RuntimeException("Failed to delete profile image");
+                }
+            }
+
+            // 리뷰 이미지 삭제
+            List<String> reviewImages = mypageMapper.getReviewImagesByUserId(userNo);
+            for (String reviewImagePath : reviewImages) {
+                boolean isFileDeleted = deleteFile(reviewImagePath);
+                if (!isFileDeleted) {
+                    throw new RuntimeException("Failed to delete review image: " + reviewImagePath);
+                }
+            }
+
+            // 리뷰 삭제
+            int reviewDeleteResult = mypageMapper.deleteReviewsByUserId(userNo);
+            if (reviewDeleteResult < 0) {
+                throw new RuntimeException("Failed to delete reviews");
+            }
+
+            // 사용자 삭제
+            int result = mypageMapper.deleteUserById(userId);
+            if (result == 0) {
+                throw new RuntimeException("Failed to delete user");
+            }
+
+            return true;
+        } catch (Exception e) {
+            // 예외 로그 출력
+            e.printStackTrace();
+            throw new RuntimeException("Error deleting user: " + e.getMessage()); // 클라이언트로 에러 메시지 전달
+        }
     }
+
+
+
 
     public boolean deleteFile(String filePath) {
         try {

--- a/src/main/resources/mappers/mypage/MypageMapper.xml
+++ b/src/main/resources/mappers/mypage/MypageMapper.xml
@@ -273,9 +273,16 @@
         WHERE USER_NO = #{userNo, jdbcType=BIGINT}
     </select>
 
-    <insert id="getUserNoByIdForNoshow" parameterType="String">
+    <select id="getUserNoByIdForNoshow" resultType="com.ohgiraffers.ukki.user.model.dto.MypageDeleteAccount">
+        SELECT USER_NO, EMAIL, NOSHOW
+        FROM TBL_USER
+        WHERE USER_ID = #{userId}
+    </select>
+
+    <insert id="insertEmailIntoNoshow" parameterType="map">
         INSERT INTO TBL_NOSHOW (EMAIL, NOSHOW)
-        VALUES (#{email, jdbcType=VARCHAR}, #{noshow, jdbcType=BIGINT})
+        VALUES (#{email}, #{noshow})
     </insert>
+
 
 </mapper>

--- a/src/main/resources/mappers/mypage/MypageMapper.xml
+++ b/src/main/resources/mappers/mypage/MypageMapper.xml
@@ -275,7 +275,7 @@
 
     <insert id="getUserNoByIdForNoshow" parameterType="String">
         INSERT INTO TBL_NOSHOW (EMAIL, NOSHOW)
-        VALUES (#{email, jdbcType=VARCHAR}, 1)
+        VALUES (#{email, jdbcType=VARCHAR}, #{noshow, jdbcType=BIGINT})
     </insert>
 
 </mapper>

--- a/src/main/resources/mappers/mypage/MypageMapper.xml
+++ b/src/main/resources/mappers/mypage/MypageMapper.xml
@@ -261,5 +261,21 @@
         WHERE USER_NO = #{userNo, jdbcType=BIGINT}
     </delete>
 
+    <select id="getNoshowCountByUserNo" parameterType="long" resultType="int">
+        SELECT NOSHOW
+        FROM TBL_USER
+        WHERE USER_NO = #{userNo, jdbcType=BIGINT}
+    </select>
+
+    <select id="getEmailByUserNo" parameterType="long" resultType="String">
+        SELECT EMAIL
+        FROM TBL_USER
+        WHERE USER_NO = #{userNo, jdbcType=BIGINT}
+    </select>
+
+    <insert id="getUserNoByIdForNoshow" parameterType="String">
+        INSERT INTO TBL_NOSHOW (EMAIL, NOSHOW)
+        VALUES (#{email, jdbcType=VARCHAR}, 1)
+    </insert>
 
 </mapper>

--- a/src/main/resources/mappers/mypage/MypageMapper.xml
+++ b/src/main/resources/mappers/mypage/MypageMapper.xml
@@ -199,10 +199,6 @@
         WHERE USER_ID = #{userId}
     </select>
 
-    <delete id="deleteUserById" parameterType="String">
-        DELETE FROM TBL_USER WHERE USER_ID = #{userId}
-    </delete>
-
     <select id="findReservationDetailByResNo" resultType="com.ohgiraffers.ukki.user.model.dto.MypageReservationDetailDTO">
         SELECT
         r.RES_NO AS resNo,
@@ -242,6 +238,28 @@
         WHERE
         er.RES_NO = #{resNo}
     </select>
+
+    <delete id="deleteUserById" parameterType="String">
+        DELETE FROM TBL_USER WHERE USER_ID = #{userId, jdbcType=VARCHAR}
+    </delete>
+
+    <select id="getUserNoById" resultType="long">
+        SELECT USER_NO
+        FROM TBL_USER
+        WHERE USER_ID = #{userId, jdbcType=VARCHAR}
+    </select>
+
+    <select id="getReviewImagesByUserId" resultType="String">
+        SELECT REVIEW_IMG
+        FROM TBL_REVIEW r
+        JOIN TBL_USER u ON r.USER_NO = u.USER_NO
+        WHERE r.USER_NO = #{userNo, jdbcType=BIGINT}
+    </select>
+
+    <delete id="deleteReviewsByUserId" parameterType="long">
+        DELETE FROM TBL_REVIEW
+        WHERE USER_NO = #{userNo, jdbcType=BIGINT}
+    </delete>
 
 
 </mapper>


### PR DESCRIPTION
## 기능 설명 (필수) 😊
> 마이페이지 계정 탈퇴 로직
<br/>

## 관련 이슈번호 (필수) ✅
#201 
<br/>

## 다른 리뷰어들이 참고해야할 사항을 적어주세요. (선택) 💬
> 1. 유저의 아이디를 가져와서 번호로 치환
> 2. 유저의 정보를 통해 noshow 횟수 확인 후, 횟수 1이상이면 노쇼 테이블에 이메일 및 노쇼횟수 삽입
> 3. 계정 프로필 이미지 제거
> 4. 작성한 리뷰 이미지 삭제
> 5. 작성한 리뷰 삭제
> 6. 아이디 제거
> 7. 성공 시 메인 리다이렉트

현재 경로 설정 문제로 기능 확인이 잘 안됩니다.

프로필 이미지 파일도 제거 되는건 다 확인했는데 리뷰는 확실하게 연결하거나 기능 전체 완성하고 여유되면 확인하겠습니다.

일단 확인한게 탈퇴는 되는데 프로필 이미지가 없을때 없으면 넘어가게 해놨는데 안넘어가고 없다고 하고 리뷰 이미지의 경우에는 확인하고 해야할 것 같긴한데 이미지 삭제 로직만 주석처리했을 땐 탈퇴가 잘 됩니다. 
<br/>

## 기능 관련한 이미지 작성바랍니다. (선택) 🖼