### PR TITLE
[FEATURE][MypageDeleteAccount]마이페이지 계정 탈퇴 유저활동 삭제 추가 & 예외 상황 대응 추가

### DIFF
--- a/src/main/java/com/ohgiraffers/ukki/user/model/dao/MypageMapper.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/dao/MypageMapper.java
@@ -63,4 +63,6 @@ public interface MypageMapper {
     List<MypageInquiryDTO> findUserInquiryByUserIdWithSearch(String userId, String search);
 
     MypageInquiryDTO findInquiryById(int inquiryNo);
+
+    int deleteUserAct(Long userNo);
 }

--- a/src/main/java/com/ohgiraffers/ukki/user/model/service/MypageService.java
+++ b/src/main/java/com/ohgiraffers/ukki/user/model/service/MypageService.java
@@ -466,29 +466,48 @@ public boolean updateProfileImage(String userId, MultipartFile profileImage) {
 
             // 프로필 이미지 삭제
             String profileImagePath = getExistingFilePath(userId);
-            if (profileImagePath != null) {
+            if (profileImagePath != null && !profileImagePath.isEmpty()) {
                 boolean isFileDeleted = deleteFile(profileImagePath);
                 if (!isFileDeleted) {
                     throw new RuntimeException("프로필 이미지 제거 실패");
                 } else {
                     System.out.println("프로필 사진 없음");
                 }
+            } else {
+                System.out.println("프로필 이미지가 존재하지 않습니다. 건너뜁니다.");
             }
 
             // 리뷰 이미지 삭제
             List<String> reviewImages = mypageMapper.getReviewImagesByUserId(userNo);
-            for (String reviewImagePath : reviewImages) {
-                boolean isFileDeleted = deleteFile(reviewImagePath);
-                if (!isFileDeleted) {
-                    throw new RuntimeException("Failed to delete review image: " + reviewImagePath);
+            if (reviewImages != null && !reviewImages.isEmpty()) {
+                for (String reviewImagePath : reviewImages) {
+                    boolean isFileDeleted = deleteFile(reviewImagePath);
+                    if (!isFileDeleted) {
+                        System.out.println("Failed to delete review image: " + reviewImagePath);
+                        continue;
+                    }
                 }
+            } else {
+                System.out.println("리뷰 이미지가 존재하지 않습니다. 건너뜁니다.");
             }
+
 
             // 리뷰 삭제
             int reviewDeleteResult = mypageMapper.deleteReviewsByUserId(userNo);
-            if (reviewDeleteResult < 0) {
-                throw new RuntimeException("Failed to delete reviews");
+            if (reviewDeleteResult < 1) {
+                System.out.println("삭제할 리뷰가 없거나 삭제에 실패했습니다. 건너뜁니다.");
+            } else {
+                System.out.println("리뷰 삭제 성공");
             }
+
+            // 유저 활동 삭제
+            int userAct = mypageMapper.deleteUserAct(userNo);
+            if (userAct < 1) {
+                System.out.println("삭제할 유저 활동이 없거나 삭제에 실패했습니다. 건너뜁니다.");
+            } else {
+                System.out.println("유저 활동 삭제 성공");
+            }
+
 
             // 사용자 삭제
             int result = mypageMapper.deleteUserById(userId);

--- a/src/main/resources/mappers/mypage/MypageMapper.xml
+++ b/src/main/resources/mappers/mypage/MypageMapper.xml
@@ -409,5 +409,9 @@
         VALUES (#{email}, #{noshow})
     </insert>
 
+    <delete id="deleteUserAct" parameterType="java.lang.Long">
+        DELETE FROM TBL_USER_ACT_INFO
+        WHERE USER_NO = #{userNo}
+    </delete>
 
 </mapper>


### PR DESCRIPTION
## 기능 설명 (필수) 😊
> 기존 계정 탈퇴 유저 활동 삭제가 없어 추가하고 비어있을 때 오류 발생하여 탈퇴 실패 예외를 막았습니다.
<br/>

## 관련 이슈번호 (필수) ✅
#237 
<br/>

## 다른 리뷰어들이 참고해야할 사항을 적어주세요. (선택) 💬
> 
<br/>

## 기능 관련한 이미지 작성바랍니다. (선택) 🖼